### PR TITLE
Add product pages with basic cart & wishlist

### DIFF
--- a/product.html
+++ b/product.html
@@ -3,12 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wall Market Online</title>
+    <title>Product Details</title>
     <link rel="stylesheet" href="./styles.css">
-    <script src="./script.js" defer></script>
+    <script src="./product.js" defer></script>
 </head>
 <body>
-    <h1>Products</h1>
-    <div id="product-list">Loading...</div>
+    <div id="product-detail">Loading...</div>
 </body>
 </html>

--- a/product.js
+++ b/product.js
@@ -1,0 +1,73 @@
+function getQueryParam(key) {
+    const params = new URLSearchParams(window.location.search);
+    return params.get(key);
+}
+
+function addToCart(productId, variantId) {
+    const cart = JSON.parse(localStorage.getItem('cart') || '[]');
+    const existing = cart.find(item => item.productId === productId && item.variantId === variantId);
+    if (existing) {
+        existing.quantity += 1;
+    } else {
+        cart.push({ productId, variantId, quantity: 1 });
+    }
+    localStorage.setItem('cart', JSON.stringify(cart));
+    alert('Added to cart');
+}
+
+function addToWishlist(productId) {
+    const wishlist = JSON.parse(localStorage.getItem('wishlist') || '[]');
+    if (!wishlist.includes(productId)) {
+        wishlist.push(productId);
+        localStorage.setItem('wishlist', JSON.stringify(wishlist));
+    }
+    alert('Added to wishlist');
+}
+
+function displayProduct(product) {
+    const container = document.getElementById('product-detail');
+    container.innerHTML = '';
+    const title = document.createElement('h1');
+    title.textContent = product.name;
+    container.appendChild(title);
+    const desc = document.createElement('p');
+    desc.textContent = product.description;
+    container.appendChild(desc);
+
+    const variantSelect = document.createElement('select');
+    product.variants.forEach(v => {
+        const option = document.createElement('option');
+        option.value = v.id;
+        option.textContent = `${v.name} - $${(v.priceCents / 100).toFixed(2)}`;
+        variantSelect.appendChild(option);
+    });
+    container.appendChild(variantSelect);
+
+    const addCartBtn = document.createElement('button');
+    addCartBtn.textContent = 'Add to Cart';
+    addCartBtn.addEventListener('click', () => {
+        addToCart(product.id, variantSelect.value);
+    });
+    container.appendChild(addCartBtn);
+
+    const addWishlistBtn = document.createElement('button');
+    addWishlistBtn.textContent = 'Add to Wishlist';
+    addWishlistBtn.addEventListener('click', () => {
+        addToWishlist(product.id);
+    });
+    container.appendChild(addWishlistBtn);
+}
+
+function loadProduct() {
+    const id = getQueryParam('id');
+    if (!id) return;
+    fetch(`http://localhost:3001/products/${encodeURIComponent(id)}`)
+        .then(res => res.json())
+        .then(product => displayProduct(product))
+        .catch(() => {
+            const container = document.getElementById('product-detail');
+            container.textContent = 'Failed to load product';
+        });
+}
+
+document.addEventListener('DOMContentLoaded', loadProduct);

--- a/script.js
+++ b/script.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const listEl = document.getElementById('product-list');
+    if (!listEl) return;
+
+    fetch('http://localhost:3001/products')
+        .then(res => res.json())
+        .then(products => {
+            products.forEach(p => {
+                const item = document.createElement('div');
+                item.className = 'product-item';
+                const link = document.createElement('a');
+                link.href = `product.html?id=${encodeURIComponent(p.id)}`;
+                link.textContent = p.name;
+                item.appendChild(link);
+                listEl.appendChild(item);
+            });
+        })
+        .catch(() => {
+            listEl.textContent = 'Failed to load products';
+        });
+});


### PR DESCRIPTION
## Summary
- show product list on the homepage
- navigate to `product.html?id=<id>` when clicking a product
- add new product page fetching product details
- add cart and wishlist storage in localStorage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68669aea8f288327849cf21407d94e76