### PR TITLE
Add cart and wishlist pages with localStorage features

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -3,15 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wall Market Online</title>
+    <title>Cart - Wall Market Online</title>
     <link rel="stylesheet" href="./styles.css">
     <script src="./script.js" defer></script>
 </head>
 <body>
-    <h1>Welcome to Wall Market Online</h1>
-    <nav>
-        <a href="cart.html">Cart</a>
-        <a href="wishlist.html">Wishlist</a>
-    </nav>
+    <h1>Shopping Cart</h1>
+    <div id="cartItems"></div>
+    <div id="cartTotalContainer">Total: <span id="cartTotal">0</span></div>
+    <a href="index.html">Back to Home</a>
 </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -48,3 +48,7 @@ Except the following regions:
 1) ```npm install```
 2) ```npm run dev``` Will start the server and the client
 3)  PROD: ```still needs to be done```
+## Local Storage Demo
+Simple `cart.html` and `wishlist.html` pages now read data from your browser's `localStorage`.
+Items in the cart display their variant, quantity and total price. Quantities can be updated and
+items removed. Wishlist products can be moved directly to the cart.

--- a/script.js
+++ b/script.js
@@ -1,0 +1,143 @@
+// Basic cart and wishlist logic using localStorage
+
+function getCart() {
+    return JSON.parse(localStorage.getItem('cart') || '[]');
+}
+
+function saveCart(cart) {
+    localStorage.setItem('cart', JSON.stringify(cart));
+}
+
+function getWishlist() {
+    return JSON.parse(localStorage.getItem('wishlist') || '[]');
+}
+
+function saveWishlist(wishlist) {
+    localStorage.setItem('wishlist', JSON.stringify(wishlist));
+}
+
+function formatPrice(cents) {
+    return '€' + (cents / 100).toFixed(2);
+}
+
+function renderCart() {
+    const container = document.getElementById('cartItems');
+    if (!container) return;
+
+    const cart = getCart();
+    container.innerHTML = '';
+    let total = 0;
+
+    cart.forEach((item, index) => {
+        const div = document.createElement('div');
+        div.className = 'cart-item';
+
+        const name = document.createElement('span');
+        name.textContent = item.name + ' (' + (item.variantName || '') + ')';
+
+        const qtyInput = document.createElement('input');
+        qtyInput.type = 'number';
+        qtyInput.min = 1;
+        qtyInput.value = item.quantity;
+        qtyInput.addEventListener('change', (e) => {
+            updateQuantity(index, parseInt(e.target.value, 10));
+        });
+
+        const price = document.createElement('span');
+        const itemTotal = item.priceCents * item.quantity;
+        price.textContent = formatPrice(itemTotal);
+
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = 'Remove';
+        removeBtn.addEventListener('click', () => removeItem(index));
+
+        div.appendChild(name);
+        div.appendChild(qtyInput);
+        div.appendChild(price);
+        div.appendChild(removeBtn);
+        container.appendChild(div);
+
+        total += itemTotal;
+    });
+
+    const totalEl = document.getElementById('cartTotal');
+    if (totalEl) totalEl.textContent = formatPrice(total);
+}
+
+function updateQuantity(index, qty) {
+    if (qty < 1) qty = 1;
+    const cart = getCart();
+    cart[index].quantity = qty;
+    saveCart(cart);
+    renderCart();
+}
+
+function removeItem(index) {
+    const cart = getCart();
+    cart.splice(index, 1);
+    saveCart(cart);
+    renderCart();
+}
+
+function renderWishlist() {
+    const container = document.getElementById('wishlistItems');
+    if (!container) return;
+
+    const items = getWishlist();
+    container.innerHTML = '';
+
+    items.forEach((item, index) => {
+        const div = document.createElement('div');
+        div.className = 'wish-item';
+
+        const name = document.createElement('span');
+        name.textContent = item.name + ' (' + (item.variantName || '') + ')';
+
+        const moveBtn = document.createElement('button');
+        moveBtn.textContent = 'Add to Cart';
+        moveBtn.addEventListener('click', () => moveToCart(index));
+
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = 'Remove';
+        removeBtn.addEventListener('click', () => removeWish(index));
+
+        div.appendChild(name);
+        div.appendChild(moveBtn);
+        div.appendChild(removeBtn);
+        container.appendChild(div);
+    });
+}
+
+function moveToCart(wishIndex) {
+    const wishlist = getWishlist();
+    const item = wishlist.splice(wishIndex, 1)[0];
+    saveWishlist(wishlist);
+
+    const cart = getCart();
+    const existing = cart.find(ci => ci.productId === item.productId && ci.variantId === item.variantId);
+    if (existing) {
+        existing.quantity += 1;
+    } else {
+        cart.push({ ...item, quantity: 1 });
+    }
+    saveCart(cart);
+    renderWishlist();
+}
+
+function removeWish(index) {
+    const wishlist = getWishlist();
+    wishlist.splice(index, 1);
+    saveWishlist(wishlist);
+    renderWishlist();
+}
+
+function initPage() {
+    if (document.getElementById('cartItems')) {
+        renderCart();
+    }
+    if (document.getElementById('wishlistItems')) {
+        renderWishlist();
+    }
+}
+
+document.addEventListener('DOMContentLoaded', initPage);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,12 @@
+body {
+    font-family: Arial, sans-serif;
+    padding: 1rem;
+}
+
+.cart-item, .wish-item {
+    margin-bottom: 0.5rem;
+}
+
+.cart-item span, .wish-item span {
+    margin-right: 0.5rem;
+}

--- a/wishlist.html
+++ b/wishlist.html
@@ -3,15 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wall Market Online</title>
+    <title>Wishlist - Wall Market Online</title>
     <link rel="stylesheet" href="./styles.css">
     <script src="./script.js" defer></script>
 </head>
 <body>
-    <h1>Welcome to Wall Market Online</h1>
-    <nav>
-        <a href="cart.html">Cart</a>
-        <a href="wishlist.html">Wishlist</a>
-    </nav>
+    <h1>Wishlist</h1>
+    <div id="wishlistItems"></div>
+    <a href="index.html">Back to Home</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build skeleton cart.html and wishlist.html
- render items from localStorage with quantity and total price
- allow removing from cart or wishlist and moving wish items to cart
- add simple navigation links and styling
- document localStorage demo in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68669aebdc9c8327b1fa92cacb224b06