### PR TITLE
Add shared nav and basic styling

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wall Market Online</title>
+    <title>Admin - Wall Market Online</title>
     <link rel="stylesheet" href="./styles.css">
     <script src="./script.js" defer></script>
 </head>
@@ -22,8 +22,8 @@
     </header>
 
     <main>
-        <h2>Welcome to Wall Market Online!</h2>
-        <p>Select a category to start shopping.</p>
+        <h2>Admin Dashboard</h2>
+        <p>Administration tools will appear here.</p>
     </main>
 
     <footer>

--- a/cart.html
+++ b/cart.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wall Market Online</title>
+    <title>Cart - Wall Market Online</title>
     <link rel="stylesheet" href="./styles.css">
     <script src="./script.js" defer></script>
 </head>
@@ -22,8 +22,8 @@
     </header>
 
     <main>
-        <h2>Welcome to Wall Market Online!</h2>
-        <p>Select a category to start shopping.</p>
+        <h2>Your Cart</h2>
+        <p>No items added yet.</p>
     </main>
 
     <footer>

--- a/profile.html
+++ b/profile.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wall Market Online</title>
+    <title>Profile - Wall Market Online</title>
     <link rel="stylesheet" href="./styles.css">
     <script src="./script.js" defer></script>
 </head>
@@ -22,8 +22,8 @@
     </header>
 
     <main>
-        <h2>Welcome to Wall Market Online!</h2>
-        <p>Select a category to start shopping.</p>
+        <h2>Your Profile</h2>
+        <p>Profile details coming soon.</p>
     </main>
 
     <footer>

--- a/readme.md
+++ b/readme.md
@@ -48,3 +48,7 @@ Except the following regions:
 1) ```npm install```
 2) ```npm run dev``` Will start the server and the client
 3)  PROD: ```still needs to be done```
+## Development Notes:
+- Added shared header and footer across pages.
+- Navigation links cover Home, Cart, Wishlist, Profile and Admin.
+- Admin link appears when `localStorage.setItem('isAdmin', 'true')` is set.

--- a/script.js
+++ b/script.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const isAdmin = localStorage.getItem('isAdmin') === 'true';
+    document.querySelectorAll('.admin-link').forEach(link => {
+        link.style.display = isAdmin ? 'list-item' : 'none';
+    });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,44 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: Arial, Helvetica, sans-serif;
+    background-color: #f4f4f4;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+header, footer {
+    background-color: #333;
+    color: #fff;
+    padding: 1rem;
+}
+
+header h1 {
+    margin: 0 0 0.5rem;
+    font-size: 1.5rem;
+}
+
+nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    gap: 1rem;
+}
+
+nav a {
+    color: #fff;
+    text-decoration: none;
+}
+
+main {
+    flex: 1;
+    padding: 1rem;
+}
+
+@media (max-width: 600px) {
+    nav ul {
+        flex-direction: column;
+    }
+}

--- a/wishlist.html
+++ b/wishlist.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wall Market Online</title>
+    <title>Wishlist - Wall Market Online</title>
     <link rel="stylesheet" href="./styles.css">
     <script src="./script.js" defer></script>
 </head>
@@ -22,8 +22,8 @@
     </header>
 
     <main>
-        <h2>Welcome to Wall Market Online!</h2>
-        <p>Select a category to start shopping.</p>
+        <h2>Your Wishlist</h2>
+        <p>You have no items in your wishlist.</p>
     </main>
 
     <footer>


### PR DESCRIPTION
## Summary
- create Cart, Wishlist, Profile and Admin placeholder pages
- add header and footer navigation across pages
- hide admin link unless `localStorage.isAdmin` is set
- implement simple layout and responsive styles
- document new navigation component

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68669b052be883278152ce2a27c487e9